### PR TITLE
Add simple UI referencing Apple Glass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # PMP-280425
+
+This project now includes a simple HTML UI referencing the Apple Glass logo. Open `index.html` in a browser to view it.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PMP-280425 UI</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
+        header { margin-bottom: 20px; }
+        .logo {
+            width: 150px;
+            height: auto;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <!-- Placeholder logo referencing Apple Glass -->
+        <img src="apple-glass-logo-placeholder.png" alt="Apple Glass Logo" class="logo" />
+        <h1>Welcome to the PMP-280425 UI</h1>
+    </header>
+    <p>This simple interface references the Apple Glass logo as a placeholder. The actual Apple Glass logo is a trademark of Apple Inc.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` containing a basic placeholder UI referencing the Apple Glass logo
- update `README.md` with instructions to open the UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684804215ebc83268aeef6060211ef8c